### PR TITLE
Feature: Verify /draft-reply no-send safety with TLA+

### DIFF
--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -19,7 +19,7 @@ jobs:
           distribution: temurin
           java-version: "21"
 
-      - name: Run formal verification (baseline)
+      - name: Run formal verification baselines
         run: node scripts/verify-draft-reply-formal.mjs --baseline
 
       - name: Run formal mutation check

--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ Run the full local gate:
 bun run check
 ```
 
-Run formal verification for draft-reply abort safety:
+Run formal verification for draft-reply safety models:
 
 ```bash
 bun run formal:verify
 ```
 
-`formal:verify` runs TLC against a finite-state model and includes a mutation check that must produce a counterexample trace.
+`formal:verify` runs TLC for the `/draft-reply` no-send safety model and the abort-safety baseline model, then executes the abort-safety mutation check that must produce a counterexample trace.
 
 ## Opencode Thread Export Utility
 

--- a/docs/verification/draft-reply-safety.md
+++ b/docs/verification/draft-reply-safety.md
@@ -1,0 +1,77 @@
+# Draft Reply No-Send Safety Verification
+
+## Purpose
+
+This note maps the TLA+ model in `formal/draft_reply_safety.tla` to the runtime
+implementation in `src/handlers/draft-reply-endpoint.ts`.
+
+The model verifies boundary-level safety for `POST /draft-reply`:
+
+- request parsing and validation branches
+- context fetch branches
+- draft generation branches
+- draft save branches
+- abort checkpoints before save
+- terminal SSE emission behavior
+
+## State And Action Mapping
+
+| Formal phase/action                                       | Runtime behavior                                                                             |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `EmitRunStarted`                                          | `encodeRunStarted(...)` is emitted when the stream starts.                                   |
+| `MalformedJsonRequest`                                    | `parseDraftReplyRequestBody` detects invalid JSON and emits `RUN_ERROR` (`invalid_request`). |
+| `InvalidRequestPayload`                                   | `parseDraftReplyRequest` throws for schema-invalid payload and emits `RUN_ERROR`.            |
+| `AbortBeforeTextStart`                                    | `assertDraftReplyNotAborted(request.signal)` before `TEXT_MESSAGE_START`.                    |
+| `ValidateRequestAndStartText`                             | `encodeTextMessageStart(...)` after request validation and pre-fetch abort check.            |
+| `ContextFetchSuccess` / `ContextFetchFailure`             | `fetchReplyContext(...)` succeeds or throws (`context_fetch_failed`).                        |
+| `AbortAfterContextFetch`                                  | abort checkpoint immediately after context fetch.                                            |
+| `DraftGenerationSuccess` / `DraftGenerationFailure`       | `extractDraftReply(...)` succeeds or throws (`draft_generation_failed`).                     |
+| `AbortBeforeDraftSave`                                    | abort checkpoint immediately before `createReplyDraft(...)`.                                 |
+| `InvokeDraftsCreateSuccess` / `InvokeDraftsCreateFailure` | `createReplyDraft(...)` succeeds (`RUN_FINISHED`) or fails (`draft_save_failed`).            |
+| `InvokeDraftsSendForbidden`                               | Explicitly modeled but disabled (`AllowDraftsSend = FALSE`).                                 |
+| `InvokeMessagesSendForbidden`                             | Explicitly modeled but disabled (`AllowMessagesSend = FALSE`).                               |
+| `StutterAtTerminal`                                       | `terminalEmitted` guards prevent additional events after terminal.                           |
+
+## Verified Safety Properties
+
+The following invariants are checked via `formal/draft_reply_safety.cfg`:
+
+1. `InvNeverSend`: `drafts.send` and `messages.send` are never invoked.
+2. `InvAtMostOneDraftSave`: `drafts.create` is invoked at most once.
+3. `InvAbortBeforeSaveNoDraft`: abort-before-save implies no draft create.
+4. `InvExactlyOneTerminalEvent`: terminal path emits exactly one of `RUN_FINISHED` or `RUN_ERROR`.
+5. `InvNoPostTerminalEmits`: stream event list does not grow after terminal.
+6. `InvFinishedImpliesDraftId`: finished runs include a draft id.
+
+## Checked Path Coverage
+
+The model includes transitions for all required path families:
+
+- success path
+- malformed JSON path
+- invalid request payload path
+- context fetch failure path
+- draft generation failure path
+- draft save failure path
+- abort paths at all pre-save checkpoints
+
+## What Is Proven
+
+- At modeled boundary level, endpoint control flow cannot invoke send APIs.
+- Draft save cannot happen more than once per run.
+- Abort before save cannot produce a created draft.
+- Terminal stream behavior remains single-terminal and terminal-final.
+- Successful terminal outcome implies draft metadata includes an id.
+
+## Out Of Scope
+
+- Gmail/provider correctness (for example, provider-side send behavior).
+- Transport-level failures outside modeled endpoint control flow.
+- Full-system proofs for routes other than `POST /draft-reply`.
+- Replacement of runtime tests; this complements existing tests.
+
+## Reproduce
+
+```bash
+bun run formal:verify
+```

--- a/formal/README.md
+++ b/formal/README.md
@@ -1,0 +1,58 @@
+# Draft Reply Formal Verification
+
+This directory contains TLA+ models for `POST /draft-reply` safety properties.
+
+## Primary Model
+
+- `draft_reply_safety.tla`
+- `draft_reply_safety.cfg`
+
+`draft_reply_safety.*` is the issue #6 boundary model for request parsing, context fetch, draft generation, draft save, abort handling, and terminal stream emission.
+
+## Legacy Focused Model
+
+- `draft-reply-abort-safety/DraftReplyAbortSafety.tla`
+- `draft-reply-abort-safety/DraftReplyAbortSafety.cfg`
+- `draft-reply-abort-safety/DraftReplyAbortSafetyMutation.cfg`
+
+The legacy model keeps a narrower abort-guard proof and mutation check.
+
+## TLC Setup
+
+1. Install Java 21 (or newer).
+2. Run `bun run formal:verify`.
+
+The verification script downloads `tla2tools.jar` automatically to
+`~/.cache/email-agent/tla2tools.jar` if it is missing.
+
+Optional overrides:
+
+- `JAVA_BIN` to pick a specific Java executable.
+- `TLA2TOOLS_JAR` to use a custom jar path.
+- `TLA2TOOLS_URL` to use a custom jar download URL.
+
+## Model Bounds And TLC Options
+
+- Single-run finite-state lifecycle (`Boot` to `Terminal`).
+- At most one `drafts.create` transition per run (`draftCreateCalls = 0` guard).
+- Forbidden send transitions (`drafts.send`, `messages.send`) are present but disabled by config constants.
+- Terminal stuttering is allowed to keep the spec deadlock-free.
+- TLC options used by the script:
+  - `-cleanup`
+  - `-workers 1`
+  - isolated `-metadir` per run
+
+## Invariants (`draft_reply_safety.cfg`)
+
+- `InvNeverSend`: `drafts.send` and `messages.send` are never invoked.
+- `InvAtMostOneDraftSave`: `drafts.create` is called at most once per run.
+- `InvAbortBeforeSaveNoDraft`: abort-before-save implies zero draft creates.
+- `InvExactlyOneTerminalEvent`: terminal state has exactly one terminal outcome (`RUN_FINISHED` xor `RUN_ERROR`).
+- `InvNoPostTerminalEmits`: no stream events are emitted after the terminal event.
+- `InvFinishedImpliesDraftId`: `RUN_FINISHED` implies a draft id exists.
+
+## Reproducible Command
+
+```bash
+bun run formal:verify
+```

--- a/formal/draft-reply-abort-safety/README.md
+++ b/formal/draft-reply-abort-safety/README.md
@@ -20,4 +20,4 @@ This TLA+ model verifies the `POST /draft-reply` save boundary around `createRep
 bun run formal:verify
 ```
 
-The command runs TLC for the production config, then reruns TLC with the mutation config and requires an invariant counterexample trace.
+The command runs all draft-reply baseline models (including no-send safety), then reruns TLC with the mutation config and requires an invariant counterexample trace.

--- a/formal/draft_reply_safety.cfg
+++ b/formal/draft_reply_safety.cfg
@@ -1,0 +1,14 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  AllowDraftsSend = FALSE
+  AllowMessagesSend = FALSE
+
+INVARIANTS
+  TypeOk
+  InvNeverSend
+  InvAtMostOneDraftSave
+  InvAbortBeforeSaveNoDraft
+  InvExactlyOneTerminalEvent
+  InvNoPostTerminalEmits
+  InvFinishedImpliesDraftId

--- a/formal/draft_reply_safety.tla
+++ b/formal/draft_reply_safety.tla
@@ -1,0 +1,368 @@
+---- MODULE draft_reply_safety ----
+EXTENDS Naturals, Sequences
+
+CONSTANTS AllowDraftsSend, AllowMessagesSend
+
+PHASES ==
+  {
+    "Boot",
+    "AfterRunStarted",
+    "RequestValidated",
+    "ContextFetched",
+    "DraftReady",
+    "Terminal"
+  }
+
+STREAM_EVENTS ==
+  {
+    "RUN_STARTED",
+    "TEXT_MESSAGE_START",
+    "TEXT_MESSAGE_CONTENT",
+    "TEXT_MESSAGE_END",
+    "RUN_FINISHED",
+    "RUN_ERROR"
+  }
+
+VARIABLES
+  phase,
+  streamEvents,
+  terminalEventIndex,
+  runFinishedEmitted,
+  runErrorEmitted,
+  draftCreateCalls,
+  draftsSendCalls,
+  messagesSendCalls,
+  abortBeforeSave,
+  draftIdPresent
+
+vars ==
+  <<
+    phase,
+    streamEvents,
+    terminalEventIndex,
+    runFinishedEmitted,
+    runErrorEmitted,
+    draftCreateCalls,
+    draftsSendCalls,
+    messagesSendCalls,
+    abortBeforeSave,
+    draftIdPresent
+  >>
+
+Append2(events, first, second) == Append(Append(events, first), second)
+
+Append3(events, first, second, third) ==
+  Append(Append(Append(events, first), second), third)
+
+Init ==
+  /\ phase = "Boot"
+  /\ streamEvents = <<>>
+  /\ terminalEventIndex = 0
+  /\ runFinishedEmitted = FALSE
+  /\ runErrorEmitted = FALSE
+  /\ draftCreateCalls = 0
+  /\ draftsSendCalls = 0
+  /\ messagesSendCalls = 0
+  /\ abortBeforeSave = FALSE
+  /\ draftIdPresent = FALSE
+
+EmitRunStarted ==
+  /\ phase = "Boot"
+  /\ phase' = "AfterRunStarted"
+  /\ streamEvents' = Append(streamEvents, "RUN_STARTED")
+  /\ UNCHANGED
+       <<
+         terminalEventIndex,
+         runFinishedEmitted,
+         runErrorEmitted,
+         draftCreateCalls,
+         draftsSendCalls,
+         messagesSendCalls,
+         abortBeforeSave,
+         draftIdPresent
+       >>
+
+MalformedJsonRequest ==
+  /\ phase = "AfterRunStarted"
+  /\ phase' = "Terminal"
+  /\ streamEvents' = Append(streamEvents, "RUN_ERROR")
+  /\ terminalEventIndex' = Len(streamEvents')
+  /\ runErrorEmitted' = TRUE
+  /\ UNCHANGED
+       <<
+         runFinishedEmitted,
+         draftCreateCalls,
+         draftsSendCalls,
+         messagesSendCalls,
+         abortBeforeSave,
+         draftIdPresent
+       >>
+
+InvalidRequestPayload ==
+  /\ phase = "AfterRunStarted"
+  /\ phase' = "Terminal"
+  /\ streamEvents' = Append(streamEvents, "RUN_ERROR")
+  /\ terminalEventIndex' = Len(streamEvents')
+  /\ runErrorEmitted' = TRUE
+  /\ UNCHANGED
+       <<
+         runFinishedEmitted,
+         draftCreateCalls,
+         draftsSendCalls,
+         messagesSendCalls,
+         abortBeforeSave,
+         draftIdPresent
+       >>
+
+AbortBeforeTextStart ==
+  /\ phase = "AfterRunStarted"
+  /\ phase' = "Terminal"
+  /\ streamEvents' = Append(streamEvents, "RUN_ERROR")
+  /\ terminalEventIndex' = Len(streamEvents')
+  /\ runErrorEmitted' = TRUE
+  /\ abortBeforeSave' = TRUE
+  /\ UNCHANGED
+       <<
+         runFinishedEmitted,
+         draftCreateCalls,
+         draftsSendCalls,
+         messagesSendCalls,
+         draftIdPresent
+       >>
+
+ValidateRequestAndStartText ==
+  /\ phase = "AfterRunStarted"
+  /\ phase' = "RequestValidated"
+  /\ streamEvents' = Append(streamEvents, "TEXT_MESSAGE_START")
+  /\ UNCHANGED
+       <<
+         terminalEventIndex,
+         runFinishedEmitted,
+         runErrorEmitted,
+         draftCreateCalls,
+         draftsSendCalls,
+         messagesSendCalls,
+         abortBeforeSave,
+         draftIdPresent
+       >>
+
+ContextFetchFailure ==
+  /\ phase = "RequestValidated"
+  /\ phase' = "Terminal"
+  /\ streamEvents' = Append2(streamEvents, "TEXT_MESSAGE_END", "RUN_ERROR")
+  /\ terminalEventIndex' = Len(streamEvents')
+  /\ runErrorEmitted' = TRUE
+  /\ UNCHANGED
+       <<
+         runFinishedEmitted,
+         draftCreateCalls,
+         draftsSendCalls,
+         messagesSendCalls,
+         abortBeforeSave,
+         draftIdPresent
+       >>
+
+ContextFetchSuccess ==
+  /\ phase = "RequestValidated"
+  /\ phase' = "ContextFetched"
+  /\ UNCHANGED
+       <<
+         streamEvents,
+         terminalEventIndex,
+         runFinishedEmitted,
+         runErrorEmitted,
+         draftCreateCalls,
+         draftsSendCalls,
+         messagesSendCalls,
+         abortBeforeSave,
+         draftIdPresent
+       >>
+
+AbortAfterContextFetch ==
+  /\ phase = "ContextFetched"
+  /\ phase' = "Terminal"
+  /\ streamEvents' = Append2(streamEvents, "TEXT_MESSAGE_END", "RUN_ERROR")
+  /\ terminalEventIndex' = Len(streamEvents')
+  /\ runErrorEmitted' = TRUE
+  /\ abortBeforeSave' = TRUE
+  /\ UNCHANGED
+       <<
+         runFinishedEmitted,
+         draftCreateCalls,
+         draftsSendCalls,
+         messagesSendCalls,
+         draftIdPresent
+       >>
+
+DraftGenerationFailure ==
+  /\ phase = "ContextFetched"
+  /\ phase' = "Terminal"
+  /\ streamEvents' = Append2(streamEvents, "TEXT_MESSAGE_END", "RUN_ERROR")
+  /\ terminalEventIndex' = Len(streamEvents')
+  /\ runErrorEmitted' = TRUE
+  /\ UNCHANGED
+       <<
+         runFinishedEmitted,
+         draftCreateCalls,
+         draftsSendCalls,
+         messagesSendCalls,
+         abortBeforeSave,
+         draftIdPresent
+       >>
+
+DraftGenerationSuccess ==
+  /\ phase = "ContextFetched"
+  /\ phase' = "DraftReady"
+  /\ UNCHANGED
+       <<
+         streamEvents,
+         terminalEventIndex,
+         runFinishedEmitted,
+         runErrorEmitted,
+         draftCreateCalls,
+         draftsSendCalls,
+         messagesSendCalls,
+         abortBeforeSave,
+         draftIdPresent
+       >>
+
+AbortBeforeDraftSave ==
+  /\ phase = "DraftReady"
+  /\ phase' = "Terminal"
+  /\ streamEvents' = Append2(streamEvents, "TEXT_MESSAGE_END", "RUN_ERROR")
+  /\ terminalEventIndex' = Len(streamEvents')
+  /\ runErrorEmitted' = TRUE
+  /\ abortBeforeSave' = TRUE
+  /\ UNCHANGED
+       <<
+         runFinishedEmitted,
+         draftCreateCalls,
+         draftsSendCalls,
+         messagesSendCalls,
+         draftIdPresent
+       >>
+
+InvokeDraftsCreateFailure ==
+  /\ phase = "DraftReady"
+  /\ draftCreateCalls = 0
+  /\ phase' = "Terminal"
+  /\ draftCreateCalls' = draftCreateCalls + 1
+  /\ streamEvents' = Append2(streamEvents, "TEXT_MESSAGE_END", "RUN_ERROR")
+  /\ terminalEventIndex' = Len(streamEvents')
+  /\ runErrorEmitted' = TRUE
+  /\ UNCHANGED
+       <<
+         runFinishedEmitted,
+         draftsSendCalls,
+         messagesSendCalls,
+         abortBeforeSave,
+         draftIdPresent
+       >>
+
+InvokeDraftsCreateSuccess ==
+  /\ phase = "DraftReady"
+  /\ draftCreateCalls = 0
+  /\ phase' = "Terminal"
+  /\ draftCreateCalls' = draftCreateCalls + 1
+  /\ streamEvents' =
+       Append3(streamEvents, "TEXT_MESSAGE_CONTENT", "TEXT_MESSAGE_END", "RUN_FINISHED")
+  /\ terminalEventIndex' = Len(streamEvents')
+  /\ runFinishedEmitted' = TRUE
+  /\ draftIdPresent' = TRUE
+  /\ UNCHANGED
+       <<
+         runErrorEmitted,
+         draftsSendCalls,
+         messagesSendCalls,
+         abortBeforeSave
+       >>
+
+InvokeDraftsSendForbidden ==
+  /\ phase = "DraftReady"
+  /\ AllowDraftsSend
+  /\ phase' = "Terminal"
+  /\ draftsSendCalls' = draftsSendCalls + 1
+  /\ streamEvents' = Append2(streamEvents, "TEXT_MESSAGE_END", "RUN_ERROR")
+  /\ terminalEventIndex' = Len(streamEvents')
+  /\ runErrorEmitted' = TRUE
+  /\ UNCHANGED
+       <<
+         runFinishedEmitted,
+         draftCreateCalls,
+         messagesSendCalls,
+         abortBeforeSave,
+         draftIdPresent
+       >>
+
+InvokeMessagesSendForbidden ==
+  /\ phase = "DraftReady"
+  /\ AllowMessagesSend
+  /\ phase' = "Terminal"
+  /\ messagesSendCalls' = messagesSendCalls + 1
+  /\ streamEvents' = Append2(streamEvents, "TEXT_MESSAGE_END", "RUN_ERROR")
+  /\ terminalEventIndex' = Len(streamEvents')
+  /\ runErrorEmitted' = TRUE
+  /\ UNCHANGED
+       <<
+         runFinishedEmitted,
+         draftCreateCalls,
+         draftsSendCalls,
+         abortBeforeSave,
+         draftIdPresent
+       >>
+
+StutterAtTerminal ==
+  /\ phase = "Terminal"
+  /\ UNCHANGED vars
+
+Next ==
+  \/ EmitRunStarted
+  \/ MalformedJsonRequest
+  \/ InvalidRequestPayload
+  \/ AbortBeforeTextStart
+  \/ ValidateRequestAndStartText
+  \/ ContextFetchFailure
+  \/ ContextFetchSuccess
+  \/ AbortAfterContextFetch
+  \/ DraftGenerationFailure
+  \/ DraftGenerationSuccess
+  \/ AbortBeforeDraftSave
+  \/ InvokeDraftsCreateFailure
+  \/ InvokeDraftsCreateSuccess
+  \/ InvokeDraftsSendForbidden
+  \/ InvokeMessagesSendForbidden
+  \/ StutterAtTerminal
+
+Spec == Init /\ [][Next]_vars
+
+TypeOk ==
+  /\ phase \in PHASES
+  /\ streamEvents \in Seq(STREAM_EVENTS)
+  /\ terminalEventIndex \in Nat
+  /\ runFinishedEmitted \in BOOLEAN
+  /\ runErrorEmitted \in BOOLEAN
+  /\ draftCreateCalls \in Nat
+  /\ draftsSendCalls \in Nat
+  /\ messagesSendCalls \in Nat
+  /\ abortBeforeSave \in BOOLEAN
+  /\ draftIdPresent \in BOOLEAN
+
+InvNeverSend ==
+  /\ draftsSendCalls = 0
+  /\ messagesSendCalls = 0
+
+InvAtMostOneDraftSave == draftCreateCalls <= 1
+
+InvAbortBeforeSaveNoDraft == abortBeforeSave => (draftCreateCalls = 0)
+
+InvExactlyOneTerminalEvent ==
+  /\ ~(runFinishedEmitted /\ runErrorEmitted)
+  /\ phase = "Terminal" =>
+       /\ runFinishedEmitted # runErrorEmitted
+       /\ terminalEventIndex > 0
+
+InvNoPostTerminalEmits == terminalEventIndex = 0 \/ terminalEventIndex = Len(streamEvents)
+
+InvFinishedImpliesDraftId == runFinishedEmitted => draftIdPresent
+
+====


### PR DESCRIPTION
## Summary
- Add a new formal state-machine model at `formal/draft_reply_safety.tla` with TLC config `formal/draft_reply_safety.cfg` to verify no-send and terminal-event safety for `POST /draft-reply`.
- Cover success, malformed JSON, invalid payload, context fetch failure, draft generation failure, draft save failure, and abort-before-save paths, including explicit forbidden `drafts.send` and `messages.send` transitions.
- Add formal docs (`formal/README.md`, `docs/verification/draft-reply-safety.md`) and update verification tooling/docs/CI naming so `bun run formal:verify` reproducibly checks the new model.

## Testing
- `bun run formal:verify`
- `bun run check`

## Post-Deploy Monitoring & Validation
- What to monitor
  - Logs: none expected from runtime path (no production handler behavior changes)
  - Metrics/Dashboards: `Formal Verification` GitHub Actions job
- Validation checks:
  - `bun run formal:verify`
- Expected healthy behavior
  - no-send safety model invariants pass; abort-safety baseline passes; abort mutation check fails with expected counterexample trace
- Failure signal(s) / rollback trigger
  - any TLC invariant violation for baseline configs, or mutation config unexpectedly passing
- Validation window and owner
  - validation window: during PR CI and post-merge CI run
  - owner: PR author
- If no runtime impact:
  - `No additional operational monitoring required: this change adds formal models, docs, and CI verification only.`

Closes #6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/backland-labs/email-agent/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
